### PR TITLE
Add generate_erd command to main.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,7 @@ target/
 #Pycharm
 .idea/
 venv/
+
+# ERD
+schema.dot
+schema.png

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,7 @@ MarkupSafe==0.23
 passlib==1.6.5
 python-dateutil==2.4.2
 pytz==2015.7
+sadisplay==0.4.2
 six==1.10.0
 SQLAlchemy==1.0.11
 Werkzeug==0.11.3


### PR DESCRIPTION
Uses [https://bitbucket.org/estin/sadisplay/wiki/Home sadisplay] to generate a UML-ish entity relationship diagram (ERD) of the database.

Must have the dot executable (provided by the graphviz package).
