### PR TITLE
Add data version number to API

### DIFF
--- a/ton/api.py
+++ b/ton/api.py
@@ -1,7 +1,15 @@
 from flask.ext.restful import Resource
 
 from .application import app
-from .models import Location
+from .models import LastUpdate, Location
+
+
+class GetDataVersion(Resource):
+
+    def get(self):
+        dt = app.db.session.query(LastUpdate).first().last_update
+
+        return int(dt.strftime("%Y%m%d%H%M%S")), 200
 
 
 class GetLocationsResource(Resource):
@@ -66,4 +74,5 @@ class GetLocationsResource(Resource):
 
 
 def api_initialize():
+    app.api.add_resource(GetDataVersion, '/api/getdataversion')
     app.api.add_resource(GetLocationsResource, '/api/getlocations')

--- a/ton/api.py
+++ b/ton/api.py
@@ -1,9 +1,7 @@
 from flask.ext.restful import Resource
 
-from sqlalchemy import func
-
 from .application import app
-from .models import User, Location
+from .models import Location
 
 
 class GetLocationsResource(Resource):
@@ -67,14 +65,5 @@ class GetLocationsResource(Resource):
         }, 200)
 
 
-class TestResource(Resource):
-    def get(self):
-        return ({
-            'message': 'ok',
-            'user_count': app.db.session.query(func.count(User.id)).scalar()
-        }, 200)
-
-
 def api_initialize():
-    app.api.add_resource(TestResource, '/api/test')
     app.api.add_resource(GetLocationsResource, '/api/getlocations')

--- a/ton/models.py
+++ b/ton/models.py
@@ -1,6 +1,7 @@
 from flask_security import RoleMixin, UserMixin
 
 from flask_sqlalchemy import SQLAlchemy
+from sqlalchemy.sql import func as sql_func
 
 db = SQLAlchemy()
 
@@ -49,7 +50,15 @@ locations_days_of_week = db.Table(
 )
 
 
-class DayOfWeek(db.Model):
+class ChangeTrackingModel(db.Model):
+    __abstract__ = True
+    created = db.Column(db.DateTime, nullable=False,
+        server_default=sql_func.current_timestamp())  # noqa
+    updated = db.Column(db.DateTime, nullable=False,
+        server_default=sql_func.current_timestamp())  # noqa
+
+
+class DayOfWeek(ChangeTrackingModel):
     __tablename__ = 'day_of_week'
     id = db.Column(db.Integer, primary_key=True)
     day = db.Column(db.String(10), nullable=False, unique=True)
@@ -58,7 +67,7 @@ class DayOfWeek(db.Model):
         return self.day
 
 
-class Location(db.Model):
+class Location(ChangeTrackingModel):
     __tablename__ = 'location'
     id = db.Column(db.Integer, primary_key=True)
     name = db.Column(db.String(80), nullable=False, unique=True)
@@ -82,7 +91,7 @@ class Location(db.Model):
         return self.name
 
 
-class Service(db.Model):
+class Service(ChangeTrackingModel):
     __tablename__ = 'service'
     id = db.Column(db.Integer, primary_key=True)
     name = db.Column(db.String(40), nullable=False, unique=True)


### PR DESCRIPTION
Closes #3 

I threw in created/updated fields on `Location`, `Service`, and `DayOfWeek` while I was at it.  They're not used at all for the API endpoint - that's managed entirely by a `before_flush` listener.  My thought is that the extra columns don't cost much and the data they hold can't be populated later.
