### PR TITLE
City state sort columns

### DIFF
--- a/ton/application.py
+++ b/ton/application.py
@@ -49,7 +49,7 @@ class SecureView(sqla.ModelView):
 
 
 class LocationModelView(SecureView):
-    _list_columns = ["name", "services"]
+    _list_columns = ["name", "services", "city", "state"]
     _form_columns = [
         ("name", "e.g. Food Bank of Alaska"),
         ("services", "Click for drop-down choices. May select multiple "
@@ -64,6 +64,8 @@ class LocationModelView(SecureView):
         ("opening_time", "Useful for locations with regular hours."),
         ("closing_time", "Useful for locations with regular hours."),
         ("days_of_week", "Useful for locations with regular hours."),
+        ("city", "Useful for sorting locations.  Not sent to mobile devices."),
+        ("state", "Useful for sorting locations.  Not sent to mobile devices."),
     ]
     can_view_details = True  # Add a "View" option for records
     column_list = _list_columns  # List view

--- a/ton/application.py
+++ b/ton/application.py
@@ -70,6 +70,7 @@ class LocationModelView(SecureView):
     can_view_details = True  # Add a "View" option for records
     column_list = _list_columns  # List view
     column_default_sort = "name"
+    column_details_list = [name for name, _ in _form_columns]
     form_columns = [name for name, _ in _form_columns]  # Form view
     column_descriptions = dict(_form_columns)  # Form view
 

--- a/ton/application.py
+++ b/ton/application.py
@@ -50,7 +50,7 @@ class SecureView(sqla.ModelView):
 
 class LocationModelView(SecureView):
     _list_columns = ["name", "services", "city", "state"]
-    _form_columns = [
+    _cols = [
         ("name", "e.g. Food Bank of Alaska"),
         ("services", "Click for drop-down choices. May select multiple "
             "services. Type to filter."),
@@ -67,12 +67,13 @@ class LocationModelView(SecureView):
         ("city", "Useful for sorting locations.  Not sent to mobile devices."),
         ("state", "Useful for sorting locations.  Not sent to mobile devices."),
     ]
-    can_view_details = True  # Add a "View" option for records
-    column_list = _list_columns  # List view
+    can_view_details = True
+    column_details_list = [name for name, _ in _cols]
     column_default_sort = "name"
-    column_details_list = [name for name, _ in _form_columns]
-    form_columns = [name for name, _ in _form_columns]  # Form view
-    column_descriptions = dict(_form_columns)  # Form view
+    column_descriptions = dict(_cols)
+    column_editable_list = ["city", "state"]
+    column_list = _list_columns  # List view only
+    form_columns = [name for name, _ in _cols if name not in ["city", "state"]]
 
 
 # Setup Flask-Admin

--- a/ton/application.py
+++ b/ton/application.py
@@ -69,6 +69,7 @@ class LocationModelView(SecureView):
     ]
     can_view_details = True  # Add a "View" option for records
     column_list = _list_columns  # List view
+    column_default_sort = "name"
     form_columns = [name for name, _ in _form_columns]  # Form view
     column_descriptions = dict(_form_columns)  # Form view
 

--- a/ton/models.py
+++ b/ton/models.py
@@ -90,6 +90,8 @@ class Location(ChangeTrackingModel):
     website = db.Column(db.String(256))
     opening_time = db.Column(db.Time)
     closing_time = db.Column(db.Time)
+    city = db.Column(db.String(80))
+    state = db.Column(db.String(80))
     days_of_week = db.relationship(
         'DayOfWeek', secondary=locations_days_of_week,
         backref=db.backref('locations', lazy='dynamic'))


### PR DESCRIPTION
Our client asked for city/state tracking to be added back into the admin interface, but not into the app.  Our client wants this so she can sort the list view by those columns.

I added two string fields to handle this and made them appear only on the list view, managed inline.
